### PR TITLE
Implement Delete method on ServiceClient

### DIFF
--- a/datapyrse/core/services/delete.py
+++ b/datapyrse/core/services/delete.py
@@ -1,0 +1,101 @@
+import requests
+from datapyrse.core.models.entity import Entity
+from datapyrse.core.models.entity_reference import EntityReference
+from uuid import UUID
+from logging import Logger
+from datapyrse.core.services.service_client import ServiceClient
+
+
+def delete_entity(
+    service_client: ServiceClient, logger: Logger = None, **kwargs
+) -> bool:
+    entity_id: str = None
+    entity_name: str = None
+
+    if not logger:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.WARN)
+    if not service_client or not service_client.IsReady:
+        logger.error("ServiceClient is not ready")
+        raise ValueError("ServiceClient is not ready")
+    if not kwargs:
+        logger.error("At least one argument is required")
+        raise ValueError("At least one argument is required")
+    logger.debug(f"Deleting entity with args: {kwargs}")
+    if "entity" in kwargs:
+        entity = kwargs["entity"]
+        if isinstance(entity, Entity):
+            if entity.entity_id is None:
+                logger.error("entity_id is required")
+                raise ValueError("entity_id is required")
+            if entity.entity_logical_name is None:
+                logger.error("entity_name is required")
+                raise ValueError("entity_name is required")
+            entity_id = str(entity.entity_id)
+            entity_name = entity.entity_logical_name
+        else:
+            logger.error("entity must be of type Entity")
+            raise ValueError("entity must be of type Entity")
+    if "entity_reference" in kwargs:
+        entity_reference = kwargs["entity_reference"]
+        if isinstance(entity_reference, EntityReference):
+            entity_id = entity_reference.entity_id
+            entity_name = entity_reference.entity_logical_name
+        else:
+            logger.error("entity_reference must be of type EntityReference")
+            raise ValueError("entity_reference must be of type EntityReference")
+    if "entity_name" in kwargs and "entity_id" in kwargs:
+        entity_id = kwargs["entity_id"]
+        entity_name = kwargs["entity_name"]
+        if not isinstance(entity_id, UUID) and not isinstance(entity_id, str):
+            logger.error("entity_id must be of type UUID or str")
+            raise ValueError("entity_id must be of type UUID or str")
+        else:
+            entity_id = str(entity_id)
+        if not isinstance(entity_name, str):
+            logger.error("entity_name must be of type str")
+            raise ValueError("entity_name must be of type str")
+    if "entity_name" in kwargs and "entity_id" not in kwargs:
+        logger.error("entity_id is required")
+        raise ValueError("entity_id is required")
+    if "entity_id" in kwargs and "entity_name" not in kwargs:
+        logger.error("entity_name is required")
+        raise ValueError("entity_name is required")
+
+    # delete entity
+    entity_metadata = next(
+        (
+            entity
+            for entity in service_client.metadata.entities
+            if entity.logical_name == entity_name
+        ),
+        None,
+    )
+    if not entity_metadata:
+        logger.error(f"Entity {entity_name} not found in metadata")
+        raise ValueError(f"Entity {entity_name} not found in metadata")
+    entity_plural_name = entity_metadata.logical_collection_name
+    if not entity_plural_name:
+        logger.error(f"Entity {entity_name} does not have a plural name")
+        raise ValueError(f"Entity {entity_name} does not have a plural name")
+
+    url: str = (
+        f"{service_client.resource_url}/api/data/v9.2/{entity_plural_name}({entity_id})"
+    )
+    headers = {
+        "OData-MaxVersion": "4.0",
+        "OData-Version": "4.0",
+        "Accept": "application/json",
+        "Content-Type": "application/json; charset=utf-8",
+        "Prefer": "return=representation;odata.metadata=none",
+        "Authorization": f"Bearer {service_client.get_access_token()}",
+    }
+    response = requests.delete(url, headers=headers)
+    response.raise_for_status()
+    if response.ok:
+        logger.info(f"Entity {entity_name} with id {entity_id} deleted")
+        return True
+    logger.error(f"Failed to delete entity {entity_name} with id {entity_id}")
+    return False

--- a/datapyrse/core/services/service_client.py
+++ b/datapyrse/core/services/service_client.py
@@ -42,8 +42,9 @@ class ServiceClient:
             self.logger.setLevel(logging.WARNING)
         if self.access_token and self.token_expiry and time.time() > self.token_expiry:
             self.IsReady = True
-
-        self.logger.debug("Service client initialized. Getting metadata...")
+        if not self.metadata:
+            self.logger.error("Failed to get metadata")
+            raise ValueError("Failed to get metadata")
 
     def _get_metadata(self) -> OrgMetadata:
         from datapyrse.core.utils.dataverse import get_metadata
@@ -114,3 +115,11 @@ class ServiceClient:
             logger = self.logger
 
         return retrieve_multiple_method(service_client=self, query=query, logger=logger)
+
+    def delete(self, logger: logging.Logger = None, **kwargs) -> bool:
+        from datapyrse.core.services.delete import delete_entity
+
+        if not logger:
+            logger = self.logger
+
+        return delete_entity(service_client=self, logger=logger, **kwargs)

--- a/tests/services/test_delete.py
+++ b/tests/services/test_delete.py
@@ -1,0 +1,288 @@
+from logging import Logger
+import uuid
+import pytest
+from unittest.mock import Mock, patch
+from uuid import UUID
+from datapyrse.core.models.entity import Entity
+from datapyrse.core.models.entity_reference import EntityReference
+from requests import HTTPError
+from datapyrse.core.services.service_client import ServiceClient
+from datapyrse.core.services.delete import (
+    delete_entity,
+)
+from datapyrse.core.models.entity_metadata import *
+
+
+@pytest.fixture
+def mock_service_client():
+    service_client = Mock(spec=ServiceClient)
+    service_client.IsReady = True
+    service_client.resource_url = "https://example.com"
+    service_client.get_access_token.return_value = "mock_token"
+    service_client.metadata = OrgMetadata(
+        entities=[
+            EntityMetadata(logical_name="account", logical_collection_name="accounts"),
+            EntityMetadata(logical_name="contact", logical_collection_name="contacts"),
+        ]
+    )
+    return service_client
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock(spec=Logger)
+
+
+@patch("requests.delete")
+def test_delete_entity_success(mock_delete, mock_service_client, mock_logger):
+    # Set up
+    entity_id = str(UUID("12345678-1234-1234-1234-123456789abc"))
+    entity_name = "account"
+
+    # Mock the requests.delete response
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_delete.return_value = mock_response
+
+    # Test with entity_name and entity_id directly
+    result = delete_entity(
+        service_client=mock_service_client,
+        logger=mock_logger,
+        entity_name=entity_name,
+        entity_id=entity_id,
+    )
+
+    # Assertions
+    assert result is True
+    mock_delete.assert_called_once_with(
+        f"https://example.com/api/data/v9.2/accounts({entity_id})",
+        headers={
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=utf-8",
+            "Prefer": "return=representation;odata.metadata=none",
+            "Authorization": "Bearer mock_token",
+        },
+    )
+    mock_logger.info.assert_called_once_with(
+        f"Entity {entity_name} with id {entity_id} deleted"
+    )
+
+
+@patch("requests.delete")
+def test_delete_entity_entity_object(mock_delete, mock_service_client, mock_logger):
+    # Create an Entity object
+    entity = Mock(spec=Entity)
+    entity.entity_id = uuid.uuid4()
+    entity.entity_logical_name = "contact"
+
+    # Mock the requests.delete response
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_delete.return_value = mock_response
+
+    # Test with an entity object
+    result = delete_entity(
+        service_client=mock_service_client, logger=mock_logger, entity=entity
+    )
+
+    # Assertions
+    assert result is True
+    mock_delete.assert_called_once()
+    mock_logger.info.assert_called_once()
+
+
+@patch("requests.delete")
+def test_delete_entity_fail(mock_delete, mock_service_client, mock_logger):
+    # Create an EntityReference object
+    entity_reference = Mock(spec=EntityReference)
+    entity_reference.entity_id = "12345678-1234-1234-1234-123456789abc"
+    entity_reference.entity_logical_name = "account"
+
+    # Mock a failed delete response
+    mock_response = Mock()
+    mock_response.ok = False
+    mock_delete.return_value = mock_response
+
+    # Test with an entity reference object
+    result = delete_entity(
+        service_client=mock_service_client,
+        logger=mock_logger,
+        entity_reference=entity_reference,
+    )
+
+    # Assertions
+    assert result is False
+    mock_delete.assert_called_once()
+    mock_logger.error.assert_called_once()
+
+
+@patch("requests.delete")
+def test_delete_entity_http_error(mock_delete, mock_service_client):
+    # Create an Entity object
+    entity = Mock(spec=Entity)
+    entity.entity_id = uuid.uuid4()
+    entity.entity_logical_name = "contact"
+
+    # Mock a request that raises an HTTPError
+    mock_delete.side_effect = HTTPError("Failed to delete")
+
+    # Test with an entity object
+    with pytest.raises(HTTPError):
+        delete_entity(service_client=mock_service_client, entity=entity)
+
+    mock_delete.assert_called_once()
+
+
+def test_delete_entity_service_client_not_ready(mock_logger):
+    # Service client not ready
+    mock_service_client = Mock(spec=ServiceClient)
+    mock_service_client.IsReady = False
+
+    with pytest.raises(ValueError, match="ServiceClient is not ready"):
+        delete_entity(service_client=mock_service_client, logger=mock_logger)
+
+    mock_logger.error.assert_called_once_with("ServiceClient is not ready")
+
+
+def test_delete_entity_missing_arguments(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="At least one argument is required"):
+        delete_entity(service_client=mock_service_client, logger=mock_logger)
+
+    mock_logger.error.assert_called_once_with("At least one argument is required")
+
+
+def test_delete_entity_entity_id_required(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_id is required"):
+        delete_entity(
+            service_client=mock_service_client, logger=mock_logger, entity=Entity()
+        )
+
+    mock_logger.error.assert_called_once_with("entity_id is required")
+
+
+def test_delete_entity_entity_name_required(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_name is required"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity=Entity(entity_id=uuid.uuid4()),
+        )
+
+    mock_logger.error.assert_called_once_with("entity_name is required")
+
+
+def test_delete_entity_entity_reference_required(mock_service_client, mock_logger):
+    with pytest.raises(
+        ValueError, match="entity_reference must be of type EntityReference"
+    ):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_reference="notAnEntityReference",
+        )
+
+    mock_logger.error.assert_called_once_with(
+        "entity_reference must be of type EntityReference"
+    )
+
+
+def test_delete_entity_entity_id_type(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_id must be of type UUID or str"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name="account",
+            entity_id=123,
+        )
+
+
+def test_delete_entity_entity_name_type(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_name must be of type str"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name=123,
+            entity_id=uuid.uuid4(),
+        )
+
+
+def test_delete_entity_entity_not_entity(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity must be of type Entity"):
+        delete_entity(
+            service_client=mock_service_client, logger=mock_logger, entity="account"
+        )
+
+
+def test_delete_entity_entity_reference_not_entity_reference(
+    mock_service_client, mock_logger
+):
+    with pytest.raises(
+        ValueError, match="entity_reference must be of type EntityReference"
+    ):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_reference="account",
+        )
+
+
+def test_delete_entity_entity_id_required(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_id is required"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name="account",
+        )
+
+
+def test_delete_entity_entity_name_required(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_name is required"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_id=uuid.uuid4(),
+        )
+
+
+def test_delete_entity_entity_name_not_str(mock_service_client, mock_logger):
+    with pytest.raises(ValueError, match="entity_name must be of type str"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name=123,
+            entity_id="12345678-1234-1234-1234-123456789abc",
+        )
+
+
+def test_delete_entity_entity_metadata_not_found(mock_service_client, mock_logger):
+    mock_service_client.metadata = OrgMetadata(
+        entities=[
+            EntityMetadata(logical_name="contact", logical_collection_name="contacts"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match=f"Entity account not found in metadata"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name="account",
+            entity_id="12345678-1234-1234-1234-123456789abc",
+        )
+
+
+def test_delete_entity_entity_plural_name_not_found(mock_service_client, mock_logger):
+    mock_service_client.metadata = OrgMetadata(
+        entities=[
+            EntityMetadata(logical_name="account"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match=f"Entity account does not have a plural name"):
+        delete_entity(
+            service_client=mock_service_client,
+            logger=mock_logger,
+            entity_name="account",
+            entity_id="12345678-1234-1234-1234-123456789abc",
+        )


### PR DESCRIPTION
This pull request adds the functionality to delete entities in the ServiceClient class. It includes the implementation of the `delete` method, which takes in the necessary parameters and sends a DELETE request to the appropriate endpoint. The method also handles error cases and returns a boolean value indicating the success of the deletion. This implementation addresses and closes Issue #4.